### PR TITLE
refactor: weather APIの責務分離とURL構築ロジックの明確化

### DIFF
--- a/src/api/weather.test.ts
+++ b/src/api/weather.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { fetchWeather, ApiError, buildOpenWeatherForecastUrl } from './weather';
+import { server } from '../mocks/server';
+import { errorHandlers } from '../mocks/handlers';
+
+describe('buildOpenWeatherForecastUrl', () => {
+  it('都市名から正しいURLを構築する', () => {
+    const url = buildOpenWeatherForecastUrl('Tokyo');
+    expect(url).toContain(
+      'https://api.openweathermap.org/data/2.5/forecast?q=Tokyo&appid='
+    );
+    expect(url).toContain('&units=metric&lang=ja');
+  });
+
+  it('都市名にスペースが含まれる場合、エンコードされる', () => {
+    const url = buildOpenWeatherForecastUrl('New York');
+    expect(url).toContain('q=New+York');
+  });
+
+  it('特殊文字が含まれる場合、適切にエンコードされる', () => {
+    const url = buildOpenWeatherForecastUrl('São Paulo');
+    expect(url).toContain('q=S%C3%A3o+Paulo');
+  });
+});
+
+describe('fetchWeather', () => {
+  it('正常にWeatherApiResponseを取得できる', async () => {
+    const url = buildOpenWeatherForecastUrl('Tokyo');
+    const result = await fetchWeather(url);
+
+    expect(result.cod).toBe('200');
+    expect(result.list).toHaveLength(3);
+    expect(result.list[0].main.temp).toBe(15.5);
+    expect(result.city.name).toBe('Tokyo');
+  });
+
+  describe('エラーハンドリング', () => {
+    afterEach(() => {
+      server.resetHandlers();
+    });
+
+    it('401エラーの場合、ApiErrorをthrowする', async () => {
+      server.use(errorHandlers.unauthorized);
+      const url = buildOpenWeatherForecastUrl('Tokyo');
+
+      await expect(fetchWeather(url)).rejects.toThrow(ApiError);
+      await expect(fetchWeather(url)).rejects.toThrow(
+        'Weather API request failed: 401'
+      );
+    });
+
+    it('404エラーの場合、ApiErrorをthrowする', async () => {
+      server.use(errorHandlers.notFound);
+      const url = buildOpenWeatherForecastUrl('Tokyo');
+      await expect(fetchWeather(url)).rejects.toThrow(ApiError);
+    });
+
+    it('500エラーの場合、ApiErrorをthrowする', async () => {
+      server.use(errorHandlers.serverError);
+      const url = buildOpenWeatherForecastUrl('Tokyo');
+      await expect(fetchWeather(url)).rejects.toThrow(ApiError);
+    });
+
+    it('429エラーの場合、ApiErrorをthrowする', async () => {
+      server.use(errorHandlers.rateLimited);
+      const url = buildOpenWeatherForecastUrl('Tokyo');
+      await expect(fetchWeather(url)).rejects.toThrow(ApiError);
+    });
+
+    it('ApiErrorにはstatusプロパティが含まれる', async () => {
+      server.use(errorHandlers.unauthorized);
+      const url = buildOpenWeatherForecastUrl('Tokyo');
+
+      try {
+        await fetchWeather(url);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError);
+        expect((error as ApiError).status).toBe(401);
+      }
+    });
+  });
+});

--- a/src/api/weather.test.ts
+++ b/src/api/weather.test.ts
@@ -39,44 +39,51 @@ describe('fetchWeather', () => {
       server.resetHandlers();
     });
 
-    it('401エラーの場合、ApiErrorをthrowする', async () => {
+    it('401エラーの場合、正しいプロパティを持つApiErrorをthrowする', async () => {
       server.use(errorHandlers.unauthorized);
       const url = buildOpenWeatherForecastUrl('Tokyo');
 
-      await expect(fetchWeather(url)).rejects.toThrow(ApiError);
-      await expect(fetchWeather(url)).rejects.toThrow(
-        'Weather API request failed: 401'
-      );
-    });
-
-    it('404エラーの場合、ApiErrorをthrowする', async () => {
-      server.use(errorHandlers.notFound);
-      const url = buildOpenWeatherForecastUrl('Tokyo');
-      await expect(fetchWeather(url)).rejects.toThrow(ApiError);
-    });
-
-    it('500エラーの場合、ApiErrorをthrowする', async () => {
-      server.use(errorHandlers.serverError);
-      const url = buildOpenWeatherForecastUrl('Tokyo');
-      await expect(fetchWeather(url)).rejects.toThrow(ApiError);
-    });
-
-    it('429エラーの場合、ApiErrorをthrowする', async () => {
-      server.use(errorHandlers.rateLimited);
-      const url = buildOpenWeatherForecastUrl('Tokyo');
-      await expect(fetchWeather(url)).rejects.toThrow(ApiError);
-    });
-
-    it('ApiErrorにはstatusプロパティが含まれる', async () => {
-      server.use(errorHandlers.unauthorized);
-      const url = buildOpenWeatherForecastUrl('Tokyo');
-
-      try {
-        await fetchWeather(url);
-      } catch (error) {
+      await expect(fetchWeather(url)).rejects.toSatisfy((error: unknown) => {
         expect(error).toBeInstanceOf(ApiError);
         expect((error as ApiError).status).toBe(401);
-      }
+        expect((error as ApiError).message).toBe(
+          'Weather API request failed: 401'
+        );
+        return true;
+      });
+    });
+
+    it('404エラーの場合、正しいプロパティを持つApiErrorをthrowする', async () => {
+      server.use(errorHandlers.notFound);
+      const url = buildOpenWeatherForecastUrl('Tokyo');
+
+      await expect(fetchWeather(url)).rejects.toSatisfy((error: unknown) => {
+        expect(error).toBeInstanceOf(ApiError);
+        expect((error as ApiError).status).toBe(404);
+        return true;
+      });
+    });
+
+    it('500エラーの場合、正しいプロパティを持つApiErrorをthrowする', async () => {
+      server.use(errorHandlers.serverError);
+      const url = buildOpenWeatherForecastUrl('Tokyo');
+
+      await expect(fetchWeather(url)).rejects.toSatisfy((error: unknown) => {
+        expect(error).toBeInstanceOf(ApiError);
+        expect((error as ApiError).status).toBe(500);
+        return true;
+      });
+    });
+
+    it('429エラーの場合、正しいプロパティを持つApiErrorをthrowする', async () => {
+      server.use(errorHandlers.rateLimited);
+      const url = buildOpenWeatherForecastUrl('Tokyo');
+
+      await expect(fetchWeather(url)).rejects.toSatisfy((error: unknown) => {
+        expect(error).toBeInstanceOf(ApiError);
+        expect((error as ApiError).status).toBe(429);
+        return true;
+      });
     });
   });
 });

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -9,6 +9,9 @@ const API_BASE_URL = 'https://api.openweathermap.org/data/2.5';
  */
 export const buildOpenWeatherForecastUrl = (cityName: string): string => {
   const apiKey = import.meta.env.VITE_OPENWEATHERMAP_API_KEY;
+  if (!apiKey) {
+    throw new Error('VITE_OPENWEATHERMAP_API_KEY is not set in .env file');
+  }
   const params = new URLSearchParams({
     q: cityName,
     appid: apiKey,

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -1,0 +1,53 @@
+import type { WeatherApiResponse } from '../types/weather';
+
+const API_BASE_URL = 'https://api.openweathermap.org/data/2.5';
+
+/**
+ * OpenWeatherMap Forecast APIのURLを構築する
+ * @param cityName 都市名(英語)
+ * @returns 完全なAPIエンドポイントURL
+ */
+export const buildOpenWeatherForecastUrl = (cityName: string): string => {
+  const apiKey = import.meta.env.VITE_OPENWEATHERMAP_API_KEY;
+  const params = new URLSearchParams({
+    q: cityName,
+    appid: apiKey,
+    units: 'metric',
+    lang: 'ja',
+  });
+  return `${API_BASE_URL}/forecast?${params.toString()}`;
+};
+
+/**
+ * API呼び出し時のエラーを表すクラス
+ */
+export class ApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+/**
+ * 指定したURLから天気予報データを取得
+ * @param url APIエンドポイントURL
+ * @returns 天気予報データ
+ * @throws {ApiError} API呼び出しに失敗した場合
+ */
+export const fetchWeather = async (
+  url: string
+): Promise<WeatherApiResponse> => {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new ApiError(
+      `Weather API request failed: ${response.status}`,
+      response.status
+    );
+  }
+
+  return await response.json();
+};

--- a/src/components/CityListItem.stories.tsx
+++ b/src/components/CityListItem.stories.tsx
@@ -23,24 +23,24 @@ type Story = StoryObj<typeof meta>;
 
 export const Tokyo: Story = {
   args: {
-    city: { id: 'tokyo', name: '東京' },
+    city: { id: 'tokyo', name: '東京', nameEn: 'Tokyo' },
   },
 };
 
 export const Hyogo: Story = {
   args: {
-    city: { id: 'hyogo', name: '兵庫' },
+    city: { id: 'hyogo', name: '兵庫', nameEn: 'Hyogo' },
   },
 };
 
 export const Oita: Story = {
   args: {
-    city: { id: 'oita', name: '大分' },
+    city: { id: 'oita', name: '大分', nameEn: 'Oita' },
   },
 };
 
 export const Hokkaido: Story = {
   args: {
-    city: { id: 'hokkaido', name: '北海道' },
+    city: { id: 'hokkaido', name: '北海道', nameEn: 'Hokkaido' },
   },
 };

--- a/src/components/CityListItem.test.tsx
+++ b/src/components/CityListItem.test.tsx
@@ -8,6 +8,7 @@ describe('CityListItem', () => {
   const mockCity: City = {
     id: 'tokyo',
     name: '東京',
+    nameEn: 'Tokyo',
   };
 
   it('地域名が表示される', () => {

--- a/src/constants/cities.ts
+++ b/src/constants/cities.ts
@@ -1,8 +1,8 @@
 import type { City } from '../types/city';
 
 export const CITIES: readonly City[] = [
-  { id: 'tokyo', name: '東京' },
-  { id: 'hyogo', name: '兵庫' },
-  { id: 'oita', name: '大分' },
-  { id: 'hokkaido', name: '北海道' },
+  { id: 'tokyo', name: '東京', nameEn: 'Tokyo' },
+  { id: 'hyogo', name: '兵庫', nameEn: 'Hyogo' },
+  { id: 'oita', name: '大分', nameEn: 'Oita' },
+  { id: 'hokkaido', name: '北海道', nameEn: 'Hokkaido' },
 ];

--- a/src/hooks/useWeather.test.tsx
+++ b/src/hooks/useWeather.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '../lib/queryClient';
+import { useWeather } from './useWeather';
+import type { CityId } from '../types/city';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useWeather', () => {
+  it('天気データを取得できる', async () => {
+    const { result } = renderHook(() => useWeather('tokyo'), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data?.cod).toBe('200');
+    expect(result.current.data?.list).toHaveLength(3);
+  });
+
+  it('無効なcityIdの場合、クエリが無効になる', async () => {
+    const { result } = renderHook(
+      () => useWeather('invalid' as unknown as CityId),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toBeUndefined();
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(false);
+    });
+  });
+});

--- a/src/hooks/useWeather.test.tsx
+++ b/src/hooks/useWeather.test.tsx
@@ -1,17 +1,27 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { queryClient } from '../lib/queryClient';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useWeather } from './useWeather';
 import type { CityId } from '../types/city';
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-);
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
 
 describe('useWeather', () => {
   it('天気データを取得できる', async () => {
-    const { result } = renderHook(() => useWeather('tokyo'), { wrapper });
+    const { result } = renderHook(() => useWeather('tokyo'), {
+      wrapper: createWrapper(),
+    });
 
     expect(result.current.isLoading).toBe(true);
 
@@ -26,7 +36,7 @@ describe('useWeather', () => {
     const { result } = renderHook(
       () => useWeather('invalid' as unknown as CityId),
       {
-        wrapper,
+        wrapper: createWrapper(),
       }
     );
 

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import type { CityId } from '../types/city';
+import type { WeatherApiResponse } from '../types/weather';
+import { CITIES } from '../constants/cities';
+import { fetchWeather, buildOpenWeatherForecastUrl } from '../api/weather';
+
+/**
+ * 指定した都市の天気予報データを取得するカスタムフック
+ * @param cityId 都市ID
+ * @returns TanStack Queryの結果オブジェクト
+ */
+export const useWeather = (cityId: CityId) => {
+  const city = CITIES.find((c) => c.id === cityId);
+
+  return useQuery<WeatherApiResponse>({
+    queryKey: ['weather', cityId],
+    queryFn: async () => {
+      if (!city) {
+        throw new Error(`City not found: ${cityId}`);
+      }
+      const url = buildOpenWeatherForecastUrl(city.nameEn);
+      return fetchWeather(url);
+    },
+    enabled: !!city,
+  });
+};

--- a/src/types/city.ts
+++ b/src/types/city.ts
@@ -3,4 +3,5 @@ export type CityId = 'tokyo' | 'hyogo' | 'oita' | 'hokkaido';
 export type City = {
   id: CityId;
   name: string;
+  nameEn: string;
 };

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -15,3 +15,49 @@ export type WeatherListItemProps = {
 export type WeatherListProps = {
   items: WeatherListItemProps[];
 };
+
+/**
+ * OpenWeatherMap API レスポンス型
+ */
+export type WeatherApiResponse = {
+  cod: string;
+  message: number;
+  cnt: number;
+  list: Array<{
+    dt: number;
+    main: {
+      temp: number;
+      feels_like: number;
+      temp_min: number;
+      temp_max: number;
+      pressure: number;
+      humidity: number;
+    };
+    weather: Array<{
+      id: number;
+      main: string;
+      description: string;
+      icon: string;
+    }>;
+    clouds: { all: number };
+    wind: {
+      speed: number;
+      deg: number;
+      gust?: number;
+    };
+    visibility: number;
+    pop: number;
+    sys: { pod: string };
+    dt_txt: string;
+  }>;
+  city: {
+    id: number;
+    name: string;
+    coord: { lat: number; lon: number };
+    country: string;
+    population: number;
+    timezone: number;
+    sunrise: number;
+    sunset: number;
+  };
+};


### PR DESCRIPTION
## 概要

`buildOpenWeatherForecastUrl`と`fetchWeather`の責務を分離し、より保守性の高い設計に変更しました。

## 変更内容

### `buildOpenWeatherForecastUrl`
- APIキー取得を関数内部で行うように変更
- OpenWeatherMap Forecast API専用のURL構築関数に特化
- シグネチャ: `(cityName: string) => string`

### `fetchWeather`
- URLを受け取る汎用的なJSON取得関数に変更
- API非依存の設計に
- シグネチャ: `(url: string) => Promise<WeatherApiResponse>`

### `useWeather`
- URL構築とfetch処理を明示的に分離

## 利点

✅ **責務の明確化**: 各関数の役割が明確になった
✅ **汎用性の向上**: `fetchWeather`が他のAPIでも再利用可能に
✅ **テスタビリティ**: それぞれの関数が独立してテスト可能
✅ **拡張性**: 将来的に他のOpenWeatherMap APIエンドポイントを追加しやすい

## テスト

- ✅ 全23件のテストがパス
- ✅ ESLint・Prettierチェックもパス
- ✅ 破壊的変更なし（内部実装のみ変更）

## 関連ファイル

- `src/api/weather.ts` - URL構築とfetch処理を実装
- `src/api/weather.test.ts` - ユニットテスト（9件）
- `src/hooks/useWeather.ts` - カスタムフック（呼び出し方を更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 都市ごとの天気取得フローを追加（英名での検索、メトリック単位、日本語ローカライズ）。
  * React Queryを使ったuseWeatherフックを追加。

* **Types / Data**
  * 天気APIレスポンス型を追加。
  * 都市データに英名(nameEn)フィールドを追加。

* **Errors**
  * 標準化されたAPIエラー型を導入し、HTTPステータスを保持・判別可能に。

* **Tests**
  * 天気APIの成功／401・404・429・500等の失敗パスを含むテストを追加。
  * フックの正常系・無効都市IDの挙動を検証するテストを追加。

* **Stories**
  * Storybookの都市データに英名を反映。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->