### PR TITLE
fix: 環境変数名をVITE_OPENWEATHER_API_KEYに統一

### DIFF
--- a/.claude/rules/openweathermap-api.md
+++ b/.claude/rules/openweathermap-api.md
@@ -11,12 +11,12 @@
 
 ### APIキーの管理
 
-- **環境変数**: `VITE_OPENWEATHERMAP_API_KEY`
+- **環境変数**: `VITE_OPENWEATHER_API_KEY`
 - APIキーは環境変数で管理し、コード内にハードコードしない
 - `.env`ファイルに設定し、`.gitignore`でバージョン管理から除外
 
 ```env
-VITE_OPENWEATHERMAP_API_KEY=your_api_key_here
+VITE_OPENWEATHER_API_KEY=your_api_key_here
 ```
 
 ### HTTPSの使用
@@ -149,7 +149,7 @@ GET http://api.openweathermap.org/geo/1.0/reverse
 ```typescript
 // 都市名から座標を取得
 const getCityCoordinates = async (cityName: string) => {
-  const apiKey = import.meta.env.VITE_OPENWEATHERMAP_API_KEY;
+  const apiKey = import.meta.env.VITE_OPENWEATHER_API_KEY;
   const response = await fetch(
     `https://api.openweathermap.org/geo/1.0/direct?q=${encodeURIComponent(cityName)}&limit=1&appid=${apiKey}`
   );
@@ -164,7 +164,7 @@ const getCityCoordinates = async (cityName: string) => {
 
 // 座標から都市名を取得
 const getCityName = async (lat: number, lon: number) => {
-  const apiKey = import.meta.env.VITE_OPENWEATHERMAP_API_KEY;
+  const apiKey = import.meta.env.VITE_OPENWEATHER_API_KEY;
   const response = await fetch(
     `https://api.openweathermap.org/geo/1.0/reverse?lat=${lat}&lon=${lon}&limit=1&appid=${apiKey}`
   );
@@ -383,7 +383,7 @@ interface WeatherApiResponse {
 }
 
 const getWeatherForecast = async (lat: number, lon: number): Promise<WeatherApiResponse> => {
-  const apiKey = import.meta.env.VITE_OPENWEATHERMAP_API_KEY;
+  const apiKey = import.meta.env.VITE_OPENWEATHER_API_KEY;
   const response = await fetch(
     `https://api.openweathermap.org/data/2.5/forecast?lat=${lat}&lon=${lon}&appid=${apiKey}&units=metric&lang=ja`
   );

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -8,9 +8,9 @@ const API_BASE_URL = 'https://api.openweathermap.org/data/2.5';
  * @returns 完全なAPIエンドポイントURL
  */
 export const buildOpenWeatherForecastUrl = (cityName: string): string => {
-  const apiKey = import.meta.env.VITE_OPENWEATHERMAP_API_KEY;
+  const apiKey = import.meta.env.VITE_OPENWEATHER_API_KEY;
   if (!apiKey) {
-    throw new Error('VITE_OPENWEATHERMAP_API_KEY is not set in .env file');
+    throw new Error('VITE_OPENWEATHER_API_KEY is not set in .env file');
   }
   const params = new URLSearchParams({
     q: cityName,

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -1,6 +1,7 @@
 import type { WeatherApiResponse } from '../types/weather';
 
 const API_BASE_URL = 'https://api.openweathermap.org/data/2.5';
+const API_KEY_ENV_VAR = 'VITE_OPENWEATHER_API_KEY';
 
 /**
  * OpenWeatherMap Forecast APIのURLを構築する
@@ -8,9 +9,9 @@ const API_BASE_URL = 'https://api.openweathermap.org/data/2.5';
  * @returns 完全なAPIエンドポイントURL
  */
 export const buildOpenWeatherForecastUrl = (cityName: string): string => {
-  const apiKey = import.meta.env.VITE_OPENWEATHER_API_KEY;
+  const apiKey = import.meta.env[API_KEY_ENV_VAR];
   if (!apiKey) {
-    throw new Error('VITE_OPENWEATHER_API_KEY is not set in .env file');
+    throw new Error(`${API_KEY_ENV_VAR} is not set in .env file`);
   }
   const params = new URLSearchParams({
     q: cityName,


### PR DESCRIPTION
## Summary
型定義とコード内で使用している環境変数名の不一致を修正しました。

## Changes
- `VITE_OPENWEATHERMAP_API_KEY` → `VITE_OPENWEATHER_API_KEY` に統一
- src/api/weather.ts: 環境変数名を修正（2箇所）
- .claude/rules/openweathermap-api.md: ドキュメントを更新
- docs/TASKS.md: 完了タスクにチェックを追加

## Test plan
- [x] 全22テストがパス
- [x] 型定義（vite-env.d.ts）との一貫性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * OpenWeather API キーの環境変数名が `VITE_OPENWEATHERMAP_API_KEY` から `VITE_OPENWEATHER_API_KEY` に変更されました。`.env` を更新してください。
  * ドキュメントと設定例（env スニペットや利用例）を新しい環境変数名に合わせて更新しました。
  * 動作や公開APIの挙動に変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->