### PR TITLE
ウィンドウフォーカス時の自動再取得を無効化

### DIFF
--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -10,7 +10,11 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: 1000 * 60 * 10, // 10分間キャッシュを新鮮とみなす
       gcTime: 1000 * 60 * 30, // 30分間キャッシュを保持
-      refetchOnWindowFocus: false, // ウィンドウフォーカス時の自動再取得を無効化
+      // 天気予報のように頻繁な更新が不要なデータがアプリケーションの主であるため、
+      // APIコールを節約する目的でデフォルトで無効化しています。
+      // リアルタイムなデータ更新が必要なクエリについては、
+      // 個別に `refetchOnWindowFocus: true` を設定してください。
+      refetchOnWindowFocus: false,
       retry: (failureCount, error) => {
         // 4xx系エラーはリトライしない（クライアントエラーは再試行しても解決しない）
         if (

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -10,6 +10,7 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: 1000 * 60 * 10, // 10分間キャッシュを新鮮とみなす
       gcTime: 1000 * 60 * 30, // 30分間キャッシュを保持
+      refetchOnWindowFocus: false, // ウィンドウフォーカス時の自動再取得を無効化
       retry: (failureCount, error) => {
         // 4xx系エラーはリトライしない（クライアントエラーは再試行しても解決しない）
         if (


### PR DESCRIPTION
## Summary
- TanStack Queryの`refetchOnWindowFocus`を`false`に設定

## 理由
- OpenWeatherMap APIのレート制限への配慮
- 天気予報は3時間ごとのデータで、タブ切り替えの度に再取得する必要性が低い
- 既に`staleTime: 10分`が設定されているため、頻繁な更新は不要
- 不要なローディング状態を減らし、ユーザー体験を向上

## 変更内容
- `src/lib/queryClient.ts`に`refetchOnWindowFocus: false`を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ウィンドウがフォーカスを再度取得したときの自動データ再取得を無効化しました。これにより、別タブから戻った際に不要なネットワークリクエストが減り、表示のちらつきや帯域消費が抑えられます。既存の再試行やその他のデータ取得挙動には影響ありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->