### PR TITLE
feat: WeatherPageに天気データ表示機能を統合 (Issue #11)

### DIFF
--- a/src/constants/cities.test.ts
+++ b/src/constants/cities.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { getCityById } from './cities';
+
+describe('getCityById', () => {
+  it('有効なIDで地域を返す', () => {
+    const city = getCityById('tokyo');
+    expect(city?.name).toBe('東京');
+  });
+
+  it('無効なIDでundefinedを返す', () => {
+    const city = getCityById('invalid');
+    expect(city).toBeUndefined();
+  });
+});

--- a/src/constants/cities.ts
+++ b/src/constants/cities.ts
@@ -6,3 +6,7 @@ export const CITIES: readonly City[] = [
   { id: 'oita', name: '大分', nameEn: 'Oita' },
   { id: 'hokkaido', name: '北海道', nameEn: 'Hokkaido' },
 ];
+
+export const getCityById = (id: string): City | undefined => {
+  return CITIES.find((city) => city.id === id);
+};

--- a/src/hooks/useWeather.test.tsx
+++ b/src/hooks/useWeather.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useWeather } from './useWeather';
-import type { CityId } from '../types/city';
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -33,12 +32,9 @@ describe('useWeather', () => {
   });
 
   it('無効なcityIdの場合、クエリが無効になる', async () => {
-    const { result } = renderHook(
-      () => useWeather('invalid' as unknown as CityId),
-      {
-        wrapper: createWrapper(),
-      }
-    );
+    const { result } = renderHook(() => useWeather('invalid'), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => {
       expect(result.current.data).toBeUndefined();

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import type { CityId } from '../types/city';
 import type { WeatherApiResponse } from '../types/weather';
 import { CITIES } from '../constants/cities';
 import { fetchWeather, buildOpenWeatherForecastUrl } from '../api/weather';
@@ -9,14 +8,14 @@ import { fetchWeather, buildOpenWeatherForecastUrl } from '../api/weather';
  * @param cityId 都市ID
  * @returns TanStack Queryの結果オブジェクト
  */
-export const useWeather = (cityId: CityId) => {
-  const city = CITIES.find((c) => c.id === cityId);
+export const useWeather = (cityId: string | undefined) => {
+  const city = cityId ? CITIES.find((c) => c.id === cityId) : undefined;
 
   return useQuery<WeatherApiResponse>({
     queryKey: ['weather', cityId],
     queryFn: async () => {
       if (!city) {
-        throw new Error(`City not found: ${cityId}`);
+        throw new Error(`City not found: ${cityId ?? 'undefined'}`);
       }
       const url = buildOpenWeatherForecastUrl(city.nameEn);
       return fetchWeather(url);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,9 +1,10 @@
 import { http, HttpResponse } from 'msw';
+import type { WeatherApiResponse } from '../types/weather';
 
 const API_BASE_URL = 'https://api.openweathermap.org/data/2.5';
 
 // モックデータ（OpenWeatherMap API 5 Day / 3 Hour Forecast の実際のレスポンス構造に準拠）
-const mockWeatherResponse = {
+const mockWeatherResponse: WeatherApiResponse = {
   cod: '200',
   message: 0,
   cnt: 3,

--- a/src/pages/WeatherPage.test.tsx
+++ b/src/pages/WeatherPage.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { WeatherPage } from './WeatherPage';
+import { server } from '../mocks/server';
+import { errorHandlers } from '../mocks/handlers';
+
+const renderWeatherPage = (cityId: string) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/weather/${cityId}`]}>
+        <Routes>
+          <Route path="/weather/:cityId" element={<WeatherPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('WeatherPage', () => {
+  it('ローディング中は「読み込み中...」を表示する', async () => {
+    renderWeatherPage('tokyo');
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('データ取得成功時は天気リストを表示する', async () => {
+    renderWeatherPage('tokyo');
+    // MSWでモックされたデータが返される
+    expect(await screen.findByText('2024-01-20 12:00:00')).toBeInTheDocument();
+  });
+
+  it('都市名が正しく表示される', async () => {
+    renderWeatherPage('tokyo');
+    expect(await screen.findByText('東京の天気')).toBeInTheDocument();
+  });
+
+  it('API取得エラー時はエラーメッセージを表示する', async () => {
+    server.use(errorHandlers.serverError);
+    renderWeatherPage('tokyo');
+    expect(
+      await screen.findByText('天気データの取得に失敗しました')
+    ).toBeInTheDocument();
+  });
+
+  it('無効なcityIDで「都市が見つかりません」を表示する', () => {
+    renderWeatherPage('invalid');
+    expect(screen.getByText('都市が見つかりません')).toBeInTheDocument();
+  });
+});

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -7,6 +7,33 @@ import type { WeatherApiResponse } from '../types/weather';
 import type { WeatherListItemProps } from '../types/weather';
 
 /**
+ * 天気データからアイコンURLを生成する
+ *
+ * @param weather - 天気データ配列
+ * @returns アイコンURL、データがない場合は空文字列
+ */
+const getWeatherIconUrl = (
+  weather: WeatherApiResponse['list'][0]['weather']
+): string => {
+  if (!weather || weather.length === 0) {
+    return '';
+  }
+  return `https://openweathermap.org/img/wn/${weather[0].icon}@2x.png`;
+};
+
+/**
+ * 天気の説明を取得する
+ *
+ * @param weather - 天気データ配列
+ * @returns 天気の説明、データがない場合は空文字列
+ */
+const getWeatherDescription = (
+  weather: WeatherApiResponse['list'][0]['weather']
+): string => {
+  return weather?.[0]?.description ?? '';
+};
+
+/**
  * OpenWeatherMap APIのレスポンスをWeatherListコンポーネント用の形式に変換する
  *
  * @param data - OpenWeatherMap APIのレスポンスデータ
@@ -21,9 +48,9 @@ const convertToWeatherListItems = (
 ): WeatherListItemProps[] => {
   return data.list.map((item) => ({
     dateTime: item.dt_txt,
-    iconUrl: `https://openweathermap.org/img/wn/${item.weather[0].icon}@2x.png`,
+    iconUrl: getWeatherIconUrl(item.weather),
     temperature: Math.round(item.main.temp * 10) / 10,
-    description: item.weather[0].description,
+    description: getWeatherDescription(item.weather),
   }));
 };
 

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -9,6 +9,25 @@ import type {
 } from '../types/weather';
 
 /**
+ * ページ全体のレイアウトコンポーネント
+ */
+const PageLayout = ({ children }: { children: React.ReactNode }) => (
+  <div className="min-h-screen bg-gray-100 p-4">{children}</div>
+);
+
+/**
+ * エラー表示用のコンポーネント
+ */
+const ErrorView = ({ message }: { message: string }) => (
+  <PageLayout>
+    <p className="text-red-600">{message}</p>
+    <Link to="/" className="text-blue-600">
+      ← ホームへ戻る
+    </Link>
+  </PageLayout>
+);
+
+/**
  * 天気データからアイコンURLを生成する
  *
  * @param weather - 天気データ配列
@@ -60,39 +79,25 @@ export function WeatherPage() {
   const { data, isLoading, isError } = useWeather(cityId);
 
   if (!city) {
-    return (
-      <div className="min-h-screen bg-gray-100 p-4">
-        <p className="text-red-600">都市が見つかりません</p>
-        <Link to="/" className="text-blue-600">
-          ← ホームへ戻る
-        </Link>
-      </div>
-    );
+    return <ErrorView message="都市が見つかりません" />;
   }
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-100 p-4">
+      <PageLayout>
         <p>読み込み中...</p>
-      </div>
+      </PageLayout>
     );
   }
 
   if (isError || !data) {
-    return (
-      <div className="min-h-screen bg-gray-100 p-4">
-        <p className="text-red-600">天気データの取得に失敗しました</p>
-        <Link to="/" className="text-blue-600">
-          ← ホームへ戻る
-        </Link>
-      </div>
-    );
+    return <ErrorView message="天気データの取得に失敗しました" />;
   }
 
   const items = convertToWeatherListItems(data);
 
   return (
-    <div className="min-h-screen bg-gray-100 p-4">
+    <PageLayout>
       <header className="mb-4 flex items-center gap-4">
         <Link to="/" className="text-blue-600 hover:text-blue-800">
           ← 戻る
@@ -102,6 +107,6 @@ export function WeatherPage() {
       <main>
         <WeatherList items={items} />
       </main>
-    </div>
+    </PageLayout>
   );
 }

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -79,7 +79,7 @@ export function WeatherPage() {
     );
   }
 
-  if (isError) {
+  if (isError || !data) {
     return (
       <div className="min-h-screen bg-gray-100 p-4">
         <p className="text-red-600">天気データの取得に失敗しました</p>
@@ -90,7 +90,7 @@ export function WeatherPage() {
     );
   }
 
-  const items = convertToWeatherListItems(data!);
+  const items = convertToWeatherListItems(data);
 
   return (
     <div className="min-h-screen bg-gray-100 p-4">

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -1,7 +1,68 @@
 import { useParams, Link } from 'react-router-dom';
+import { useWeather } from '../hooks/useWeather';
+import { WeatherList } from '../components/WeatherList';
+import { getCityById } from '../constants/cities';
+import type { CityId } from '../types/city';
+import type { WeatherApiResponse } from '../types/weather';
+import type { WeatherListItemProps } from '../types/weather';
+
+/**
+ * OpenWeatherMap APIのレスポンスをWeatherListコンポーネント用の形式に変換する
+ *
+ * @param data - OpenWeatherMap APIのレスポンスデータ
+ * @returns WeatherListコンポーネントに渡すアイテムの配列
+ *
+ * @remarks
+ * - 気温は小数第1位に丸められます
+ * - 天気アイコンのURLはOpenWeatherMapの公式CDNを使用します
+ */
+const convertToWeatherListItems = (
+  data: WeatherApiResponse
+): WeatherListItemProps[] => {
+  return data.list.map((item) => ({
+    dateTime: item.dt_txt,
+    iconUrl: `https://openweathermap.org/img/wn/${item.weather[0].icon}@2x.png`,
+    temperature: Math.round(item.main.temp * 10) / 10,
+    description: item.weather[0].description,
+  }));
+};
 
 export function WeatherPage() {
   const { cityId } = useParams<{ cityId: string }>();
+  const city = getCityById(cityId ?? '');
+  const { data, isLoading, isError } = useWeather(cityId as CityId);
+
+  if (!city) {
+    return (
+      <div className="min-h-screen bg-gray-100 p-4">
+        <p className="text-red-600">都市が見つかりません</p>
+        <Link to="/" className="text-blue-600">
+          ← ホームへ戻る
+        </Link>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-100 p-4">
+        <p>読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="min-h-screen bg-gray-100 p-4">
+        <p className="text-red-600">天気データの取得に失敗しました</p>
+        <Link to="/" className="text-blue-600">
+          ← ホームへ戻る
+        </Link>
+      </div>
+    );
+  }
+
+  const items = convertToWeatherListItems(data!);
 
   return (
     <div className="min-h-screen bg-gray-100 p-4">
@@ -9,11 +70,10 @@ export function WeatherPage() {
         <Link to="/" className="text-blue-600 hover:text-blue-800">
           ← 戻る
         </Link>
-        <h1 className="text-2xl font-bold text-gray-800">{cityId}の天気</h1>
+        <h1 className="text-2xl font-bold text-gray-800">{city.name}の天気</h1>
       </header>
       <main>
-        {/* WeatherList コンポーネントを後で追加 */}
-        <p className="text-gray-600">天気データを表示予定</p>
+        <WeatherList items={items} />
       </main>
     </div>
   );

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -3,8 +3,11 @@ import { useWeather } from '../hooks/useWeather';
 import { WeatherList } from '../components/WeatherList';
 import { getCityById } from '../constants/cities';
 import type { CityId } from '../types/city';
-import type { WeatherApiResponse } from '../types/weather';
-import type { WeatherListItemProps } from '../types/weather';
+import type {
+  WeatherApiResponse,
+  WeatherForecastItem,
+  WeatherListItemProps,
+} from '../types/weather';
 
 /**
  * 天気データからアイコンURLを生成する
@@ -12,9 +15,7 @@ import type { WeatherListItemProps } from '../types/weather';
  * @param weather - 天気データ配列
  * @returns アイコンURL、データがない場合は空文字列
  */
-const getWeatherIconUrl = (
-  weather: WeatherApiResponse['list'][0]['weather']
-): string => {
+const getWeatherIconUrl = (weather: WeatherForecastItem['weather']): string => {
   if (!weather || weather.length === 0) {
     return '';
   }
@@ -28,7 +29,7 @@ const getWeatherIconUrl = (
  * @returns 天気の説明、データがない場合は空文字列
  */
 const getWeatherDescription = (
-  weather: WeatherApiResponse['list'][0]['weather']
+  weather: WeatherForecastItem['weather']
 ): string => {
   return weather?.[0]?.description ?? '';
 };
@@ -46,7 +47,7 @@ const getWeatherDescription = (
 const convertToWeatherListItems = (
   data: WeatherApiResponse
 ): WeatherListItemProps[] => {
-  return data.list.map((item) => ({
+  return data.list.map((item: WeatherForecastItem) => ({
     dateTime: item.dt_txt,
     iconUrl: getWeatherIconUrl(item.weather),
     temperature: Math.round(item.main.temp * 10) / 10,

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -2,7 +2,6 @@ import { useParams, Link } from 'react-router-dom';
 import { useWeather } from '../hooks/useWeather';
 import { WeatherList } from '../components/WeatherList';
 import { getCityById } from '../constants/cities';
-import type { CityId } from '../types/city';
 import type {
   WeatherApiResponse,
   WeatherForecastItem,
@@ -58,7 +57,7 @@ const convertToWeatherListItems = (
 export function WeatherPage() {
   const { cityId } = useParams<{ cityId: string }>();
   const city = getCityById(cityId ?? '');
-  const { data, isLoading, isError } = useWeather(cityId as CityId);
+  const { data, isLoading, isError } = useWeather(cityId);
 
   if (!city) {
     return (

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -17,43 +17,56 @@ export type WeatherListProps = {
 };
 
 /**
+ * OpenWeatherMap API の予報データ1件分の型
+ * 3時間ごとの天気予報情報を表す
+ */
+export type WeatherForecastItem = {
+  dt: number;
+  dt_txt: string;
+  main: {
+    temp: number;
+    feels_like: number;
+    temp_min: number;
+    temp_max: number;
+    pressure: number;
+    humidity: number;
+  };
+  weather: Array<{
+    id: number;
+    main: string;
+    description: string;
+    icon: string;
+  }>;
+  clouds: {
+    all: number;
+  };
+  wind: {
+    speed: number;
+    deg: number;
+    gust?: number;
+  };
+  visibility: number;
+  pop: number;
+  sys: {
+    pod: string;
+  };
+};
+
+/**
  * OpenWeatherMap API レスポンス型
  */
 export type WeatherApiResponse = {
   cod: string;
   message: number;
   cnt: number;
-  list: Array<{
-    dt: number;
-    main: {
-      temp: number;
-      feels_like: number;
-      temp_min: number;
-      temp_max: number;
-      pressure: number;
-      humidity: number;
-    };
-    weather: Array<{
-      id: number;
-      main: string;
-      description: string;
-      icon: string;
-    }>;
-    clouds: { all: number };
-    wind: {
-      speed: number;
-      deg: number;
-      gust?: number;
-    };
-    visibility: number;
-    pop: number;
-    sys: { pod: string };
-    dt_txt: string;
-  }>;
+  list: WeatherForecastItem[];
   city: {
     id: number;
     name: string;
-    coord: { lat: number; lon: number };
+    coord: {
+      lat: number;
+      lon: number;
+    };
     country: string;
     population: number;
     timezone: number;


### PR DESCRIPTION
## Summary

WeatherPageにuseWeather、WeatherList、getCityByIdを統合し、天気画面を完成させました。
ローディング、成功、エラー、無効なcityIDの各状態を実装しています。

## 実装内容

### 新規追加
- `getCityById`関数 - 都市IDから都市情報を取得
- `convertToWeatherListItems`関数 - APIレスポンスをWeatherList形式に変換
- `WeatherPage.test.tsx` - 統合テスト（5件）
- `cities.test.ts` - getCityByIdのテスト（2件）

### WeatherPageの機能
- ✅ ローディング状態の表示
- ✅ データ取得成功時にWeatherListを表示
- ✅ 都市名の正しい表示（city.nameを使用）
- ✅ API取得エラー時のエラーメッセージ表示
- ✅ 無効なcityID時の「都市が見つかりません」表示
- ✅ ホームへ戻るリンク

## テスト結果

- ✅ 全29件のテストがパス（新規7件追加）
- ✅ ESLint検証パス
- ✅ Prettier検証パス
- ✅ ビルド成功

## 動作確認

以下のURLで動作確認可能：
- `/weather/tokyo` - 東京の天気データ表示
- `/weather/invalid` - 無効なID時のエラー表示

## 関連Issue

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 都市IDから都市情報を取得するユーティリティを追加し、天気ページで都市名を解決して天気一覧を表示。

* **フック**
  * 天気取得フックが undefined を受け入れ、都市不在時は自動で取得を無効化・エラーハンドリングを改善。

* **テスト**
  * 都市取得の単体テストを追加。
  * 天気ページの表示（読み込み・成功・APIエラー・無効な都市）を検証するテストを追加。

* **型定義**
  * 天気APIの予報アイテム型を追加・明確化。

* **モック**
  * モックレスポンスに明示的な型注釈を追加（動作に影響なし）。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->