### PR TITLE
feat: エラー画面にリトライボタンを追加

### DIFF
--- a/src/components/ErrorView.stories.tsx
+++ b/src/components/ErrorView.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MemoryRouter } from 'react-router-dom';
+import { ErrorView } from './ErrorView';
+
+const meta = {
+  title: 'Components/ErrorView',
+  component: ErrorView,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof ErrorView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * リトライボタンなしの基本的なエラー表示
+ */
+export const BasicError: Story = {
+  args: {
+    message: '都市が見つかりません',
+    showRetryButton: false,
+  },
+};
+
+/**
+ * リトライボタンありのエラー表示
+ */
+export const RetryableError: Story = {
+  args: {
+    message: 'サーバーでエラーが発生しました。時間をおいて再度お試しください。',
+    showRetryButton: true,
+    onRetry: () => alert('リトライボタンがクリックされました'),
+  },
+};
+
+/**
+ * 401エラー - APIキーが無効
+ */
+export const UnauthorizedError: Story = {
+  args: {
+    message: 'APIキーが無効です。設定を確認してください。',
+    showRetryButton: true,
+    onRetry: () => alert('リトライボタンがクリックされました'),
+  },
+};
+
+/**
+ * 404エラー - 都市が見つからない
+ */
+export const NotFoundError: Story = {
+  args: {
+    message: '指定された都市の天気情報が見つかりません。',
+    showRetryButton: true,
+    onRetry: () => alert('リトライボタンがクリックされました'),
+  },
+};
+
+/**
+ * 429エラー - レート制限超過
+ */
+export const RateLimitError: Story = {
+  args: {
+    message:
+      'APIのリクエスト制限を超過しました。しばらく待ってから再度お試しください。',
+    showRetryButton: true,
+    onRetry: () => alert('リトライボタンがクリックされました'),
+  },
+};
+
+/**
+ * 500エラー - サーバーエラー
+ */
+export const ServerError: Story = {
+  args: {
+    message: 'サーバーでエラーが発生しました。時間をおいて再度お試しください。',
+    showRetryButton: true,
+    onRetry: () => alert('リトライボタンがクリックされました'),
+  },
+};
+
+/**
+ * 長いエラーメッセージ
+ */
+export const LongErrorMessage: Story = {
+  args: {
+    message:
+      '予期しないエラーが発生しました。ネットワーク接続を確認するか、しばらく時間をおいてから再度お試しください。問題が解決しない場合は、管理者にお問い合わせください。',
+    showRetryButton: true,
+    onRetry: () => alert('リトライボタンがクリックされました'),
+  },
+};

--- a/src/components/ErrorView.test.tsx
+++ b/src/components/ErrorView.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { ErrorView } from './ErrorView';
+
+describe('ErrorView', () => {
+  it('showRetryButtonがfalseの場合、リトライボタンは表示されない', () => {
+    render(
+      <MemoryRouter>
+        <ErrorView message="エラーが発生しました" showRetryButton={false} />
+      </MemoryRouter>
+    );
+    expect(
+      screen.queryByRole('button', { name: '再試行' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('showRetryButtonがtrueでonRetryがある場合、リトライボタンが表示される', () => {
+    render(
+      <MemoryRouter>
+        <ErrorView
+          message="エラーが発生しました"
+          showRetryButton={true}
+          onRetry={() => {}}
+        />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('button', { name: '再試行' })).toBeInTheDocument();
+  });
+
+  it('リトライボタンをクリックするとonRetryが呼ばれる', async () => {
+    const onRetry = vi.fn();
+    render(
+      <MemoryRouter>
+        <ErrorView
+          message="エラーが発生しました"
+          showRetryButton={true}
+          onRetry={onRetry}
+        />
+      </MemoryRouter>
+    );
+
+    const button = screen.getByRole('button', { name: '再試行' });
+    await userEvent.click(button);
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ErrorView.tsx
+++ b/src/components/ErrorView.tsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router-dom';
+
+interface ErrorViewProps {
+  message: string;
+  showRetryButton: boolean;
+  onRetry?: () => void;
+}
+
+/**
+ * エラー表示用のコンポーネント
+ */
+export const ErrorView = ({
+  message,
+  showRetryButton,
+  onRetry,
+}: ErrorViewProps) => (
+  <div className="min-h-screen bg-gray-100 p-4">
+    <p className="text-red-600">{message}</p>
+    <div className="mt-4">
+      {showRetryButton && onRetry && (
+        <button
+          onClick={onRetry}
+          className="mr-4 rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+        >
+          再試行
+        </button>
+      )}
+      <Link to="/" className="text-blue-600">
+        ← ホームへ戻る
+      </Link>
+    </div>
+  </div>
+);

--- a/src/components/ErrorView.tsx
+++ b/src/components/ErrorView.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { PageLayout } from './PageLayout';
 
 interface ErrorViewProps {
   message: string;
@@ -14,7 +15,7 @@ export const ErrorView = ({
   showRetryButton,
   onRetry,
 }: ErrorViewProps) => (
-  <div className="min-h-screen bg-gray-100 p-4">
+  <PageLayout>
     <p className="text-red-600">{message}</p>
     <div className="mt-4">
       {showRetryButton && onRetry && (
@@ -29,5 +30,5 @@ export const ErrorView = ({
         ← ホームへ戻る
       </Link>
     </div>
-  </div>
+  </PageLayout>
 );

--- a/src/components/PageLayout.stories.tsx
+++ b/src/components/PageLayout.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { PageLayout } from './PageLayout';
+
+const meta = {
+  title: 'Components/PageLayout',
+  component: PageLayout,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PageLayout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * 基本的なPageLayoutの使用例
+ */
+export const Basic: Story = {
+  args: {
+    children: (
+      <div className="text-center">
+        <h1 className="text-2xl font-bold mb-4">ページタイトル</h1>
+        <p className="text-gray-600">ページのコンテンツがここに表示されます</p>
+      </div>
+    ),
+  },
+};
+
+/**
+ * カードコンテンツを含むレイアウト
+ */
+export const WithCard: Story = {
+  args: {
+    children: (
+      <div className="max-w-md mx-auto">
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-bold mb-2">カードタイトル</h2>
+          <p className="text-gray-600">
+            カード内のコンテンツです。PageLayoutは背景とパディングを提供します。
+          </p>
+        </div>
+      </div>
+    ),
+  },
+};
+
+/**
+ * 複数の要素を含むレイアウト
+ */
+export const WithMultipleElements: Story = {
+  args: {
+    children: (
+      <div className="max-w-2xl mx-auto space-y-4">
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-bold mb-2">セクション1</h2>
+          <p className="text-gray-600">最初のセクションのコンテンツ</p>
+        </div>
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-bold mb-2">セクション2</h2>
+          <p className="text-gray-600">2番目のセクションのコンテンツ</p>
+        </div>
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-bold mb-2">セクション3</h2>
+          <p className="text-gray-600">3番目のセクションのコンテンツ</p>
+        </div>
+      </div>
+    ),
+  },
+};

--- a/src/components/PageLayout.test.tsx
+++ b/src/components/PageLayout.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PageLayout } from './PageLayout';
+
+describe('PageLayout', () => {
+  it('子要素を表示する', () => {
+    render(
+      <PageLayout>
+        <p>テストコンテンツ</p>
+      </PageLayout>
+    );
+
+    expect(screen.getByText('テストコンテンツ')).toBeInTheDocument();
+  });
+
+  it('適切なクラス名を持つ', () => {
+    const { container } = render(
+      <PageLayout>
+        <p>テストコンテンツ</p>
+      </PageLayout>
+    );
+
+    const layoutDiv = container.firstChild as HTMLElement;
+    expect(layoutDiv).toHaveClass('min-h-screen', 'bg-gray-100', 'p-4');
+  });
+});

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,5 +1,7 @@
+import type { ReactNode } from 'react';
+
 interface PageLayoutProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 /**

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,0 +1,10 @@
+interface PageLayoutProps {
+  children: React.ReactNode;
+}
+
+/**
+ * ページ全体のレイアウトコンポーネント
+ */
+export const PageLayout = ({ children }: PageLayoutProps) => (
+  <div className="min-h-screen bg-gray-100 p-4">{children}</div>
+);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,7 +4,7 @@ import type { WeatherApiResponse } from '../types/weather';
 const API_BASE_URL = 'https://api.openweathermap.org/data/2.5';
 
 // モックデータ（OpenWeatherMap API 5 Day / 3 Hour Forecast の実際のレスポンス構造に準拠）
-const mockWeatherResponse: WeatherApiResponse = {
+export const mockWeatherResponse: WeatherApiResponse = {
   cod: '200',
   message: 0,
   cnt: 3,

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -1,6 +1,7 @@
 import { useParams, Link } from 'react-router-dom';
 import { useWeather } from '../hooks/useWeather';
 import { WeatherList } from '../components/WeatherList';
+import { ErrorView } from '../components/ErrorView';
 import { getCityById } from '../constants/cities';
 import { getErrorMessage } from '../lib/errorMessages';
 import type {
@@ -14,18 +15,6 @@ import type {
  */
 const PageLayout = ({ children }: { children: React.ReactNode }) => (
   <div className="min-h-screen bg-gray-100 p-4">{children}</div>
-);
-
-/**
- * エラー表示用のコンポーネント
- */
-const ErrorView = ({ message }: { message: string }) => (
-  <PageLayout>
-    <p className="text-red-600">{message}</p>
-    <Link to="/" className="text-blue-600">
-      ← ホームへ戻る
-    </Link>
-  </PageLayout>
 );
 
 /**
@@ -77,13 +66,14 @@ const convertToWeatherListItems = (
 export function WeatherPage() {
   const { cityId } = useParams<{ cityId: string }>();
   const city = getCityById(cityId ?? '');
-  const { data, isLoading, isError, error } = useWeather(cityId);
+  const { data, isLoading, isError, error, refetch, isFetching } =
+    useWeather(cityId);
 
   if (!city) {
-    return <ErrorView message="都市が見つかりません" />;
+    return <ErrorView message="都市が見つかりません" showRetryButton={false} />;
   }
 
-  if (isLoading) {
+  if (isLoading || isFetching) {
     return (
       <PageLayout>
         <p>読み込み中...</p>
@@ -92,7 +82,13 @@ export function WeatherPage() {
   }
 
   if (isError || !data) {
-    return <ErrorView message={getErrorMessage(error)} />;
+    return (
+      <ErrorView
+        message={getErrorMessage(error)}
+        showRetryButton={true}
+        onRetry={refetch}
+      />
+    );
   }
 
   const items = convertToWeatherListItems(data);

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -66,14 +66,13 @@ const convertToWeatherListItems = (
 export function WeatherPage() {
   const { cityId } = useParams<{ cityId: string }>();
   const city = getCityById(cityId ?? '');
-  const { data, isLoading, isError, error, refetch, isFetching } =
-    useWeather(cityId);
+  const { data, isError, error, refetch, isFetching } = useWeather(cityId);
 
   if (!city) {
     return <ErrorView message="都市が見つかりません" showRetryButton={false} />;
   }
 
-  if (isLoading || isFetching) {
+  if (isFetching) {
     return (
       <PageLayout>
         <p>読み込み中...</p>

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -2,6 +2,7 @@ import { useParams, Link } from 'react-router-dom';
 import { useWeather } from '../hooks/useWeather';
 import { WeatherList } from '../components/WeatherList';
 import { ErrorView } from '../components/ErrorView';
+import { PageLayout } from '../components/PageLayout';
 import { getCityById } from '../constants/cities';
 import { getErrorMessage } from '../lib/errorMessages';
 import type {
@@ -9,13 +10,6 @@ import type {
   WeatherForecastItem,
   WeatherListItemProps,
 } from '../types/weather';
-
-/**
- * ページ全体のレイアウトコンポーネント
- */
-const PageLayout = ({ children }: { children: React.ReactNode }) => (
-  <div className="min-h-screen bg-gray-100 p-4">{children}</div>
-);
 
 /**
  * 天気データからアイコンURLを生成する


### PR DESCRIPTION
## 概要

エラー発生時にユーザーが手動で再取得を試みることができるリトライボタンを追加しました。

## 変更内容

### 新規作成
- **ErrorView.tsx**: ErrorViewコンポーネント（WeatherPageから抽出）
- **ErrorView.test.tsx**: ErrorViewのユニットテスト（3テスト）
- **ErrorView.stories.tsx**: Storybook用のStory（7パターン）

### 修正
- **WeatherPage.tsx**: refetch/isFetchingでリトライ機能実装
- **WeatherPage.test.tsx**: リトライのテスト追加（3テスト）
- **handlers.ts**: mockWeatherResponseをエクスポート

## 実装の特徴

- \`showRetryButton\`（必須）と\`onRetry\`（オプショナル）でリトライボタンの表示を制御
- リトライ中は\`isFetching\`でローディング状態を表示
- APIエラー時のみリトライボタンを表示（都市が見つからない場合は非表示）

## テスト

- ✅ 全44テスト通過
- MSW \`delay\`でリトライ中のローディング状態をテスト

## スクリーンショット

Storybookで以下のパターンを確認できます：
- BasicError（リトライなし）
- RetryableError（リトライあり）
- 各種HTTPエラー（401, 404, 429, 500）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 統一されたエラー画面を追加（複数の状態表示、長文対応、ホームリンク、条件付きリトライ）
  * ページ全体の共通レイアウトコンポーネントを追加
* **Storybook**
  * エラー画面とレイアウトの複数シナリオを追加
* **テスト**
  * エラー表示・リトライ挙動・再試行時の読み込み状態・レイアウトレンダリングのテストを追加
* **雑務**
  * テスト用モックデータを外部公開化

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->