### PR TITLE
feat: PageLayoutにmax-width設定を追加してコンテンツを中央配置

### DIFF
--- a/src/components/PageLayout.stories.tsx
+++ b/src/components/PageLayout.stories.tsx
@@ -29,17 +29,16 @@ export const Basic: Story = {
 
 /**
  * カードコンテンツを含むレイアウト
+ * PageLayoutがmax-widthとセンタリングを提供
  */
 export const WithCard: Story = {
   args: {
     children: (
-      <div className="max-w-md mx-auto">
-        <div className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-xl font-bold mb-2">カードタイトル</h2>
-          <p className="text-gray-600">
-            カード内のコンテンツです。PageLayoutは背景とパディングを提供します。
-          </p>
-        </div>
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h2 className="text-xl font-bold mb-2">カードタイトル</h2>
+        <p className="text-gray-600">
+          カード内のコンテンツです。PageLayoutは背景、パディング、max-width、センタリングを提供します。
+        </p>
       </div>
     ),
   },
@@ -47,11 +46,12 @@ export const WithCard: Story = {
 
 /**
  * 複数の要素を含むレイアウト
+ * PageLayoutがmax-widthとセンタリングを提供
  */
 export const WithMultipleElements: Story = {
   args: {
     children: (
-      <div className="max-w-2xl mx-auto space-y-4">
+      <div className="space-y-4">
         <div className="bg-white rounded-lg shadow-md p-6">
           <h2 className="text-xl font-bold mb-2">セクション1</h2>
           <p className="text-gray-600">最初のセクションのコンテンツ</p>

--- a/src/components/PageLayout.test.tsx
+++ b/src/components/PageLayout.test.tsx
@@ -20,12 +20,12 @@ describe('PageLayout', () => {
       </PageLayout>
     );
 
-    // 外側のdiv: 背景とパディング
-    const layoutDiv = container.firstChild as HTMLElement;
-    expect(layoutDiv).toHaveClass('min-h-screen', 'bg-gray-100', 'p-4');
-
     // 内側のdiv: コンテンツの最大幅とセンタリング
-    const contentDiv = layoutDiv.firstChild as HTMLElement;
+    const contentDiv = screen.getByText('テストコンテンツ').parentElement;
     expect(contentDiv).toHaveClass('max-w-2xl', 'mx-auto');
+
+    // 外側のdiv: 背景とパディング
+    const layoutDiv = contentDiv?.parentElement;
+    expect(layoutDiv).toHaveClass('min-h-screen', 'bg-gray-100', 'p-4');
   });
 });

--- a/src/components/PageLayout.test.tsx
+++ b/src/components/PageLayout.test.tsx
@@ -20,7 +20,12 @@ describe('PageLayout', () => {
       </PageLayout>
     );
 
+    // 外側のdiv: 背景とパディング
     const layoutDiv = container.firstChild as HTMLElement;
     expect(layoutDiv).toHaveClass('min-h-screen', 'bg-gray-100', 'p-4');
+
+    // 内側のdiv: コンテンツの最大幅とセンタリング
+    const contentDiv = layoutDiv.firstChild as HTMLElement;
+    expect(contentDiv).toHaveClass('max-w-2xl', 'mx-auto');
   });
 });

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -8,5 +8,7 @@ interface PageLayoutProps {
  * ページ全体のレイアウトコンポーネント
  */
 export const PageLayout = ({ children }: PageLayoutProps) => (
-  <div className="min-h-screen bg-gray-100 p-4">{children}</div>
+  <div className="min-h-screen bg-gray-100 p-4">
+    <div className="max-w-2xl mx-auto">{children}</div>
+  </div>
 );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,14 +1,15 @@
 import { CityList } from '../components/CityList';
+import { PageLayout } from '../components/PageLayout';
 
 export function HomePage() {
   return (
-    <div className="min-h-screen bg-gray-100 p-4">
+    <PageLayout>
       <header className="mb-4">
         <h1 className="text-2xl font-bold text-gray-800">天気予報アプリ</h1>
       </header>
       <main>
         <CityList />
       </main>
-    </div>
+    </PageLayout>
   );
 }


### PR DESCRIPTION
## 概要
PC表示時に横幅が広すぎる問題を解決するため、PageLayoutにmax-width設定を追加しました。

## 変更内容
- PageLayoutに2層div構造を導入（外側: 背景、内側: コンテンツ幅制限）
- max-w-2xl（672px）とmx-autoでコンテンツを中央配置
- HomePageでPageLayoutを使用してレイアウトを統一
- Storybookのストーリーを更新（冗長なmax-width削除）
- レスポンシブ対応（モバイルは全幅表示）

## テスト
- ✅ 全テスト成功（49件）
- ✅ PageLayoutのテストを2層構造対応に更新

## 確認方法
### ブラウザでの確認
- PC表示（画面幅 > 672px）: コンテンツが中央に配置され、最大幅672pxに制限
- モバイル表示（画面幅 < 672px）: コンテンツが全幅表示

### Storybookでの確認
```bash
npm run storybook
```
PageLayout > WithCard、WithMultipleElements でレイアウトを確認できます

## 変更ファイル
- src/components/PageLayout.tsx
- src/components/PageLayout.test.tsx
- src/pages/HomePage.tsx
- src/components/PageLayout.stories.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ページレイアウトを改善し、最大幅とセンタリングの制約をコンポーネント側に統合してレイアウトの一貫性を向上しました。ページの使用箇所は新しいレイアウトを利用するよう更新されています。
* **Tests**
  * レイアウト変更に合わせてテストを更新し、新しい構造で期待される表示が保たれることを確認しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->