### PR TITLE
feat: CityListItemにchevronアイコンを追加

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+/>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+    />
     <title>weather-forecast-temp</title>
   </head>
   <body>

--- a/src/components/CityListItem.test.tsx
+++ b/src/components/CityListItem.test.tsx
@@ -29,4 +29,15 @@ describe('CityListItem', () => {
     const link = screen.getByRole('link', { name: '東京' });
     expect(link).toHaveAttribute('href', '/weather/tokyo');
   });
+
+  it('chevronアイコンが表示される', () => {
+    render(
+      <BrowserRouter>
+        <CityListItem city={mockCity} />
+      </BrowserRouter>
+    );
+    const chevron = screen.getByText('chevron_right');
+    expect(chevron).toBeInTheDocument();
+    expect(chevron).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/src/components/CityListItem.test.tsx
+++ b/src/components/CityListItem.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import { CityListItem } from './CityListItem';
 import type { City } from '../types/city';
@@ -11,31 +11,24 @@ describe('CityListItem', () => {
     nameEn: 'Tokyo',
   };
 
-  it('地域名が表示される', () => {
+  beforeEach(() => {
     render(
       <BrowserRouter>
         <CityListItem city={mockCity} />
       </BrowserRouter>
     );
+  });
+
+  it('地域名が表示される', () => {
     expect(screen.getByText('東京')).toBeInTheDocument();
   });
 
   it('クリックで正しいURLに遷移する', () => {
-    render(
-      <BrowserRouter>
-        <CityListItem city={mockCity} />
-      </BrowserRouter>
-    );
     const link = screen.getByRole('link', { name: '東京' });
     expect(link).toHaveAttribute('href', '/weather/tokyo');
   });
 
   it('chevronアイコンが表示される', () => {
-    render(
-      <BrowserRouter>
-        <CityListItem city={mockCity} />
-      </BrowserRouter>
-    );
     const chevron = screen.getByText('chevron_right');
     expect(chevron).toBeInTheDocument();
     expect(chevron).toHaveAttribute('aria-hidden', 'true');

--- a/src/components/CityListItem.tsx
+++ b/src/components/CityListItem.tsx
@@ -11,7 +11,7 @@ export function CityListItem({ city }: CityListItemProps) {
       to={`/weather/${city.id}`}
       className="group flex items-center justify-between p-4 bg-white border border-gray-200 hover:bg-blue-50 active:bg-blue-100 transition-colors duration-200"
     >
-      <span className="flex-1 text-lg text-blue-600 group-hover:text-blue-700">
+      <span className="flex-1 text-lg text-blue-600 group-hover:text-blue-700 transition-colors duration-200">
         {city.name}
       </span>
       <span

--- a/src/components/CityListItem.tsx
+++ b/src/components/CityListItem.tsx
@@ -9,9 +9,17 @@ export function CityListItem({ city }: CityListItemProps) {
   return (
     <Link
       to={`/weather/${city.id}`}
-      className="block p-4 bg-white border border-gray-200 hover:bg-gray-50 transition-colors duration-200"
+      className="group flex items-center justify-between p-4 bg-white border border-gray-200 hover:bg-blue-50 active:bg-blue-100 transition-colors duration-200"
     >
-      <span className="text-lg text-gray-800">{city.name}</span>
+      <span className="flex-1 text-lg text-blue-600 group-hover:text-blue-700">
+        {city.name}
+      </span>
+      <span
+        className="material-symbols-outlined text-blue-500 group-hover:text-blue-600 transition-colors duration-200"
+        aria-hidden="true"
+      >
+        chevron_right
+      </span>
     </Link>
   );
 }


### PR DESCRIPTION
## Summary

Issue #29 に対応し、CityListItemにchevronアイコンを追加してリンクであることを明確にしました。

- Material Symbols の `chevron_right` アイコンを右端に配置
- テキストとchevronを青系に統一してリンクらしいデザインに
- hover/active時のフィードバックを改善

## Changes

### Material Symbols導入
- `index.html` にCDNリンクを追加
- `.storybook/preview-head.html` を作成してStorybook対応

### CityListItem改善
- `block` → `flex items-center justify-between` に変更
- テキスト: `text-blue-600` → hover時 `text-blue-700`
- chevron: `text-blue-500` → hover時 `text-blue-600`
- 背景: hover時 `bg-blue-50`、active時 `bg-blue-100`
- chevronに `aria-hidden="true"` を設定（装飾的要素）

### テスト
- chevronアイコン表示のテストを追加
- 既存テスト含め全50件パス

## Test plan

- [x] 全テスト実行: `npm run test:run` (50件パス)
- [x] Lint/Format: `npm run lint && npm run format`
- [ ] 手動確認: `npm run dev` でホームページを表示しchevronとhover動作を確認
- [ ] Storybook確認: `npm run storybook` でCityListItemを確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * シティリスト項目に右矢印のナビゲーションアイコンを追加
  * Material Symbols Outlinedフォントを導入してアイコン表示を有効化

* **改善**
  * シティリスト項目のレイアウトとホバー／アクティブ時の視覚フィードバックを強化（色・配置・スペース調整）

* **テスト**
  * アイコン表示と属性を検証するテストケースを追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->