### PR TITLE
feat: 共通Headerコンポーネントを実装

### DIFF
--- a/src/App.integration.test.tsx
+++ b/src/App.integration.test.tsx
@@ -45,6 +45,36 @@ describe('App - 結合テスト', () => {
     server.use(trackingHandler);
   });
 
+  describe('Header表示', () => {
+    it('ホーム画面でHeaderが表示される', () => {
+      renderApp();
+
+      // ヘッダータイトルが表示される
+      expect(
+        screen.getByRole('heading', { level: 1, name: '天気予報アプリ' })
+      ).toBeInTheDocument();
+
+      // 戻るボタンは表示されない
+      expect(screen.queryByLabelText('戻る')).not.toBeInTheDocument();
+    });
+
+    it('天気画面でHeaderが表示される', async () => {
+      renderApp();
+
+      // 1. 東京をクリックして天気画面へ遷移
+      const tokyoLink = screen.getByRole('link', { name: '東京' });
+      await userEvent.click(tokyoLink);
+
+      // 2. ヘッダータイトルが表示される
+      expect(
+        await screen.findByRole('heading', { level: 1, name: '東京の天気' })
+      ).toBeInTheDocument();
+
+      // 3. 戻るボタンが表示される
+      expect(screen.getByLabelText('戻る')).toBeInTheDocument();
+    });
+  });
+
   describe('画面遷移', () => {
     it('ホーム画面 → 天気画面へ遷移できる', async () => {
       renderApp();
@@ -71,8 +101,8 @@ describe('App - 結合テスト', () => {
       await userEvent.click(tokyoLink);
       expect(await screen.findByText('東京の天気')).toBeInTheDocument();
 
-      // 2. 「← 戻る」リンクをクリック
-      const backLink = screen.getByRole('link', { name: '← 戻る' });
+      // 2. 「戻る」リンクをクリック
+      const backLink = screen.getByRole('link', { name: '戻る' });
       await userEvent.click(backLink);
 
       // 3. ホーム画面に戻ることを確認
@@ -94,7 +124,7 @@ describe('App - 結合テスト', () => {
       expect(requestCount).toBe(1);
 
       // 3. ホームに戻る
-      const backLink = screen.getByRole('link', { name: '← 戻る' });
+      const backLink = screen.getByRole('link', { name: '戻る' });
       await userEvent.click(backLink);
       expect(await screen.findByText('天気予報アプリ')).toBeInTheDocument();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,58 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation, matchPath } from 'react-router-dom';
+import { Header } from './components/Header';
+import { PageLayout } from './components/PageLayout';
 import { HomePage } from './pages/HomePage';
 import { WeatherPage } from './pages/WeatherPage';
+import { getCityById } from './constants/cities';
+
+interface HeaderProps {
+  title: string;
+  showBackButton: boolean;
+  backTo?: string;
+}
+
+const getHeaderProps = (pathname: string): HeaderProps => {
+  // ホーム画面
+  if (pathname === '/') {
+    return {
+      title: '天気予報アプリ',
+      showBackButton: false,
+    };
+  }
+
+  // 天気画面
+  const weatherMatch = matchPath('/weather/:cityId', pathname);
+  if (weatherMatch) {
+    const { cityId } = weatherMatch.params;
+    const city = getCityById(cityId || '');
+    return {
+      title: city ? `${city.name}の天気` : '天気',
+      showBackButton: true,
+      backTo: '/',
+    };
+  }
+
+  // デフォルト
+  return {
+    title: '天気予報アプリ',
+    showBackButton: false,
+  };
+};
 
 function App() {
+  const location = useLocation();
+  const headerProps = getHeaderProps(location.pathname);
+
   return (
-    <Routes>
-      <Route path="/" element={<HomePage />} />
-      <Route path="/weather/:cityId" element={<WeatherPage />} />
-    </Routes>
+    <>
+      <Header {...headerProps} />
+      <PageLayout>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/weather/:cityId" element={<WeatherPage />} />
+        </Routes>
+      </PageLayout>
+    </>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,14 +7,6 @@ import { getCityById } from './constants/cities';
 import type { HeaderProps } from './types/header';
 
 const getHeaderProps = (pathname: string): HeaderProps => {
-  // ホーム画面
-  if (pathname === '/') {
-    return {
-      title: '天気予報アプリ',
-      showBackButton: false,
-    };
-  }
-
   // 天気画面
   const weatherMatch = matchPath('/weather/:cityId', pathname);
   if (weatherMatch) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,7 @@ import { PageLayout } from './components/PageLayout';
 import { HomePage } from './pages/HomePage';
 import { WeatherPage } from './pages/WeatherPage';
 import { getCityById } from './constants/cities';
-
-interface HeaderProps {
-  title: string;
-  showBackButton: boolean;
-  backTo?: string;
-}
+import type { HeaderProps } from './types/header';
 
 const getHeaderProps = (pathname: string): HeaderProps => {
   // ホーム画面

--- a/src/components/ErrorView.tsx
+++ b/src/components/ErrorView.tsx
@@ -1,5 +1,4 @@
 import { Link } from 'react-router-dom';
-import { PageLayout } from './PageLayout';
 
 interface ErrorViewProps {
   message: string;
@@ -15,7 +14,7 @@ export const ErrorView = ({
   showRetryButton,
   onRetry,
 }: ErrorViewProps) => (
-  <PageLayout>
+  <>
     <p className="text-red-600">{message}</p>
     <div className="mt-4">
       {showRetryButton && onRetry && (
@@ -30,5 +29,5 @@ export const ErrorView = ({
         ← ホームへ戻る
       </Link>
     </div>
-  </PageLayout>
+  </>
 );

--- a/src/components/Header.stories.tsx
+++ b/src/components/Header.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MemoryRouter } from 'react-router-dom';
+import { Header } from './Header';
+
+const meta: Meta<typeof Header> = {
+  title: 'Components/Header',
+  component: Header,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  args: {
+    title: '天気予報アプリ',
+    showBackButton: false,
+  },
+};
+
+export const WithBackButton: Story = {
+  args: {
+    title: '東京の天気',
+    showBackButton: true,
+    backTo: '/',
+  },
+};
+
+export const CustomBackTo: Story = {
+  args: {
+    title: 'カスタムページ',
+    showBackButton: true,
+    backTo: '/custom',
+  },
+};

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { Header } from './Header';
+
+describe('Header', () => {
+  it('タイトルが表示される', () => {
+    render(
+      <MemoryRouter>
+        <Header title="天気予報アプリ" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      '天気予報アプリ'
+    );
+  });
+
+  it('戻るボタンがデフォルトで非表示', () => {
+    render(
+      <MemoryRouter>
+        <Header title="天気予報アプリ" />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByLabelText('戻る')).not.toBeInTheDocument();
+  });
+
+  it('showBackButton={true}で戻るボタンが表示される', () => {
+    render(
+      <MemoryRouter>
+        <Header title="天気予報アプリ" showBackButton={true} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText('戻る')).toBeInTheDocument();
+  });
+
+  it('backToプロパティで戻るリンク先を設定できる', () => {
+    render(
+      <MemoryRouter>
+        <Header title="天気予報アプリ" showBackButton={true} backTo="/custom" />
+      </MemoryRouter>
+    );
+
+    const backButton = screen.getByLabelText('戻る');
+    expect(backButton).toHaveAttribute('href', '/custom');
+  });
+
+  it('arrow_backアイコンが表示される', () => {
+    render(
+      <MemoryRouter>
+        <Header title="天気予報アプリ" showBackButton={true} />
+      </MemoryRouter>
+    );
+
+    const backButton = screen.getByLabelText('戻る');
+    const icon = backButton.querySelector('.material-symbols-outlined');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveTextContent('arrow_back');
+  });
+});

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,33 @@
+import { Link } from 'react-router-dom';
+
+interface HeaderProps {
+  title: string;
+  showBackButton?: boolean;
+  backTo?: string;
+}
+
+export const Header = ({
+  title,
+  showBackButton = false,
+  backTo = '/',
+}: HeaderProps) => {
+  return (
+    <header className="w-full h-14 flex items-center justify-center px-4 relative bg-white border-b border-gray-200">
+      {showBackButton && (
+        <Link
+          to={backTo}
+          aria-label="戻る"
+          className="absolute left-4 text-blue-600 hover:text-blue-800 transition-colors duration-200"
+        >
+          <span
+            className="material-symbols-outlined text-2xl"
+            aria-hidden="true"
+          >
+            arrow_back
+          </span>
+        </Link>
+      )}
+      <h1 className="text-lg font-bold text-gray-800">{title}</h1>
+    </header>
+  );
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,5 @@
 import { Link } from 'react-router-dom';
-
-interface HeaderProps {
-  title: string;
-  showBackButton?: boolean;
-  backTo?: string;
-}
+import type { HeaderProps } from '../types/header';
 
 export const Header = ({
   title,

--- a/src/components/PageLayout.test.tsx
+++ b/src/components/PageLayout.test.tsx
@@ -14,7 +14,7 @@ describe('PageLayout', () => {
   });
 
   it('適切なクラス名を持つ', () => {
-    const { container } = render(
+    render(
       <PageLayout>
         <p>テストコンテンツ</p>
       </PageLayout>

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -4,15 +4,6 @@ import { BrowserRouter } from 'react-router-dom';
 import { HomePage } from './HomePage';
 
 describe('HomePage', () => {
-  it('タイトルが表示される', () => {
-    render(
-      <BrowserRouter>
-        <HomePage />
-      </BrowserRouter>
-    );
-    expect(screen.getByText('天気予報アプリ')).toBeInTheDocument();
-  });
-
   it('地域リストが表示される', () => {
     render(
       <BrowserRouter>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,15 +1,9 @@
 import { CityList } from '../components/CityList';
-import { PageLayout } from '../components/PageLayout';
 
 export function HomePage() {
   return (
-    <PageLayout>
-      <header className="mb-4">
-        <h1 className="text-2xl font-bold text-gray-800">天気予報アプリ</h1>
-      </header>
-      <main>
-        <CityList />
-      </main>
-    </PageLayout>
+    <main>
+      <CityList />
+    </main>
   );
 }

--- a/src/pages/WeatherPage.test.tsx
+++ b/src/pages/WeatherPage.test.tsx
@@ -40,11 +40,6 @@ describe('WeatherPage', () => {
     expect(await screen.findByText('2024-01-20 12:00:00')).toBeInTheDocument();
   });
 
-  it('都市名が正しく表示される', async () => {
-    renderWeatherPage('tokyo');
-    expect(await screen.findByText('東京の天気')).toBeInTheDocument();
-  });
-
   it('401エラー時はAPIキーが無効である旨のメッセージを表示する', async () => {
     server.use(errorHandlers.unauthorized);
     renderWeatherPage('tokyo');

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -1,8 +1,7 @@
-import { useParams, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useWeather } from '../hooks/useWeather';
 import { WeatherList } from '../components/WeatherList';
 import { ErrorView } from '../components/ErrorView';
-import { PageLayout } from '../components/PageLayout';
 import { getCityById } from '../constants/cities';
 import { getErrorMessage } from '../lib/errorMessages';
 import type {
@@ -67,11 +66,7 @@ export function WeatherPage() {
   }
 
   if (isFetching) {
-    return (
-      <PageLayout>
-        <p>読み込み中...</p>
-      </PageLayout>
-    );
+    return <p>読み込み中...</p>;
   }
 
   if (isError || !data) {
@@ -87,16 +82,8 @@ export function WeatherPage() {
   const items = convertToWeatherListItems(data);
 
   return (
-    <PageLayout>
-      <header className="mb-4 flex items-center gap-4">
-        <Link to="/" className="text-blue-600 hover:text-blue-800">
-          ← 戻る
-        </Link>
-        <h1 className="text-2xl font-bold text-gray-800">{city.name}の天気</h1>
-      </header>
-      <main>
-        <WeatherList items={items} />
-      </main>
-    </PageLayout>
+    <main>
+      <WeatherList items={items} />
+    </main>
   );
 }

--- a/src/types/header.ts
+++ b/src/types/header.ts
@@ -1,0 +1,8 @@
+/**
+ * Headerコンポーネントで使用するProps型
+ */
+export type HeaderProps = {
+  title: string;
+  showBackButton?: boolean;
+  backTo?: string;
+};


### PR DESCRIPTION
## Summary
- 全幅表示の共通Headerコンポーネントを実装
- タイトル中央配置、戻るボタン（Material Symbols arrow_backアイコン）
- URLベースでHeader情報を自動管理
- TDDアプローチで実装（55テストすべてパス）

## 実装内容
### 新規ファイル
- `src/components/Header.tsx` - Headerコンポーネント本体
- `src/components/Header.test.tsx` - ユニットテスト（5テスト）
- `src/components/Header.stories.tsx` - Storybook（3ストーリー）

### 修正ファイル
- `src/App.tsx` - HeaderとPageLayoutを追加、URLベースのHeader情報管理
- `src/pages/HomePage.tsx` - PageLayoutとheader要素を削除
- `src/pages/WeatherPage.tsx` - PageLayoutとheader要素を削除
- `src/components/ErrorView.tsx` - PageLayoutを削除
- テストファイルを更新

## レイアウト構造
```
┌─ App.tsx ─────────────────────────────────┐
│ ┌─ Header (全幅) ────────────────────────┐ │
│ │ [タイトル・戻るボタン]                   │ │
│ └────────────────────────────────────────┘ │
│ ┌─ PageLayout (背景・パディング) ────────┐ │
│ │ ┌─ max-w-2xl mx-auto ─┐               │ │
│ │ │ [Routes]             │               │ │
│ │ └──────────────────────┘               │ │
│ └────────────────────────────────────────┘ │
└────────────────────────────────────────────┘
```

## Test plan
- [x] 全テスト実行（55テストすべてパス）
- [x] リント・フォーマットチェック
- [x] Storybookで各ストーリー確認
- [ ] 手動確認：ホーム画面でHeaderが全幅表示される
- [ ] 手動確認：天気画面で戻るボタンが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * アプリ全体に表示されるヘッダーを追加し、画面ごとにタイトルと戻るボタンを表示できるようになりました
  * ストーリーブックでヘッダーの表示パターンを確認可能になりました

* **Tests**
  * ヘッダー表示とナビゲーション動作を検証するテストを追加・更新しました（戻るボタンラベルの調整含む）

* **Chores**
  * 各ページのレイアウトを簡素化し、不要な wrappers を削除しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->