### PR TITLE
WeatherListItemのレイアウトを改善

### DIFF
--- a/src/components/WeatherList.tsx
+++ b/src/components/WeatherList.tsx
@@ -3,7 +3,7 @@ import { WeatherListItem } from './WeatherListItem';
 
 export function WeatherList({ items }: WeatherListProps) {
   return (
-    <div className="space-y-2">
+    <>
       {items.map((item, index) => (
         <WeatherListItem
           key={`${item.dateTime}-${index}`}
@@ -13,6 +13,6 @@ export function WeatherList({ items }: WeatherListProps) {
           description={item.description}
         />
       ))}
-    </div>
+    </>
   );
 }

--- a/src/components/WeatherListItem.tsx
+++ b/src/components/WeatherListItem.tsx
@@ -11,7 +11,7 @@ export const WeatherListItem = ({
       <p className="text-sm text-gray-600 mb-1">{dateTime}</p>
       <div className="flex items-center justify-start gap-4">
         <div className="flex flex-col items-center">
-          <img src={iconUrl} alt={description} className="h-20 w-20" />
+          <img src={iconUrl} alt={description} className="h-20 w-20" width="80" height="80" />
           <p className="text-sm text-gray-600 mt-1">{description}</p>
         </div>
         <p className="text-2xl font-bold">{temperature}℃</p>

--- a/src/components/WeatherListItem.tsx
+++ b/src/components/WeatherListItem.tsx
@@ -7,16 +7,14 @@ export const WeatherListItem = ({
   description,
 }: WeatherListItemProps) => {
   return (
-    <div className="flex items-center justify-between border-b border-gray-200 p-4 hover:bg-gray-50">
-      <div className="flex-1">
-        <p className="text-sm text-gray-600">{dateTime}</p>
-      </div>
-      <div className="flex items-center gap-4">
-        <img src={iconUrl} alt={description} className="h-12 w-12" />
-        <div className="text-center">
-          <p className="text-2xl font-bold">{temperature}℃</p>
-          <p className="text-sm text-gray-600">{description}</p>
+    <div className="bg-white border-b border-gray-200 p-2">
+      <p className="text-sm text-gray-600 mb-1">{dateTime}</p>
+      <div className="flex items-center justify-start gap-4">
+        <div className="flex flex-col items-center">
+          <img src={iconUrl} alt={description} className="h-20 w-20" />
+          <p className="text-sm text-gray-600 mt-1">{description}</p>
         </div>
+        <p className="text-2xl font-bold">{temperature}℃</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
天気カードの視認性を向上させるため、レイアウトを改善しました。

## 変更内容
- アイコンサイズを48px→80pxに拡大
- レイアウトを2段構造に変更（日時→アイコン+天気名→気温）
- アイコンと天気名を縦スタックで配置
- ホバー効果を削除し、背景を白に固定
- パディングとマージンを削減してコンパクトに
- WeatherListから不要なspace-y-2を削除

## テスト
- 既存の4つのテストがすべてパス

## 関連Issue
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * 天気リストアイテムのレイアウトを垂直構造に改善しました。
  * 天気アイコンのサイズを拡大し、より目立つようにしました。
  * 日付、説明、気温表示の配置を最適化し、可読性を向上させました。
  * コンテナのスペーシングを調整しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->