### PR TITLE
ローディングスケルトンのアニメーション追加

### DIFF
--- a/src/components/LoadingSkeleton.stories.tsx
+++ b/src/components/LoadingSkeleton.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LoadingSkeleton } from './LoadingSkeleton';
+
+const meta = {
+  title: 'Components/LoadingSkeleton',
+  component: LoadingSkeleton,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof LoadingSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const FewItems: Story = {
+  args: {
+    count: 3,
+  },
+};
+
+export const ManyItems: Story = {
+  args: {
+    count: 10,
+  },
+};

--- a/src/components/LoadingSkeleton.test.tsx
+++ b/src/components/LoadingSkeleton.test.tsx
@@ -12,20 +12,20 @@ describe('LoadingSkeleton', () => {
   });
 
   it('デフォルトで5つのアイテムが表示される', () => {
-    const { container } = render(<LoadingSkeleton />);
-    const items = container.querySelectorAll('.bg-white.border-b');
+    render(<LoadingSkeleton />);
+    const items = screen.getAllByTestId('weather-skeleton-item');
     expect(items).toHaveLength(5);
   });
 
   it('countプロパティで表示数を変更できる', () => {
-    const { container } = render(<LoadingSkeleton count={3} />);
-    const items = container.querySelectorAll('.bg-white.border-b');
+    render(<LoadingSkeleton count={3} />);
+    const items = screen.getAllByTestId('weather-skeleton-item');
     expect(items).toHaveLength(3);
   });
 
   it('日付ラベルが適切な位置に表示される', () => {
-    const { container } = render(<LoadingSkeleton />);
-    const dateLabels = container.querySelectorAll('.bg-gray-200.px-4.py-2');
+    render(<LoadingSkeleton />);
+    const dateLabels = screen.getAllByTestId('date-skeleton-label');
     expect(dateLabels).toHaveLength(2);
   });
 });

--- a/src/components/LoadingSkeleton.test.tsx
+++ b/src/components/LoadingSkeleton.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { LoadingSkeleton } from './LoadingSkeleton';
+
+describe('LoadingSkeleton', () => {
+  it('ローディングステータスとして表示される', () => {
+    render(<LoadingSkeleton />);
+    const skeleton = screen.getByRole('status', { name: '読み込み中' });
+
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('デフォルトで5つのアイテムが表示される', () => {
+    const { container } = render(<LoadingSkeleton />);
+    const items = container.querySelectorAll('.bg-white.border-b');
+    expect(items).toHaveLength(5);
+  });
+
+  it('countプロパティで表示数を変更できる', () => {
+    const { container } = render(<LoadingSkeleton count={3} />);
+    const items = container.querySelectorAll('.bg-white.border-b');
+    expect(items).toHaveLength(3);
+  });
+
+  it('日付ラベルが適切な位置に表示される', () => {
+    const { container } = render(<LoadingSkeleton />);
+    const dateLabels = container.querySelectorAll('.bg-gray-200.px-4.py-2');
+    expect(dateLabels).toHaveLength(2);
+  });
+});

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -40,7 +40,7 @@ export function LoadingSkeleton({ count = 5 }: LoadingSkeletonProps) {
     <div role="status" aria-live="polite" aria-label="読み込み中">
       {Array.from({ length: count }).map((_, index) => (
         <Fragment key={index}>
-          {(index === 0 || index === 3) && <DateSkeletonLabel />}
+          {index % 4 === 0 && <DateSkeletonLabel />}
           <WeatherSkeletonItem />
         </Fragment>
       ))}

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -36,9 +36,11 @@ export function DateSkeletonLabel() {
 }
 
 export function LoadingSkeleton({ count = 5 }: LoadingSkeletonProps) {
+  const safeCount = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+
   return (
     <div role="status" aria-live="polite" aria-label="読み込み中">
-      {Array.from({ length: count }).map((_, index) => (
+      {Array.from({ length: safeCount }).map((_, index) => (
         <Fragment key={index}>
           {index % 4 === 0 && <DateSkeletonLabel />}
           <WeatherSkeletonItem />

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -6,7 +6,10 @@ interface LoadingSkeletonProps {
 
 export function WeatherSkeletonItem() {
   return (
-    <div className="bg-white border-b border-gray-200 p-4">
+    <div
+      className="bg-white border-b border-gray-200 p-4"
+      data-testid="weather-skeleton-item"
+    >
       <div className="h-5 w-40 bg-gray-300 rounded animate-pulse mb-1" />
 
       <div className="flex items-center justify-start gap-4">
@@ -23,7 +26,10 @@ export function WeatherSkeletonItem() {
 
 export function DateSkeletonLabel() {
   return (
-    <div className="bg-gray-200 px-4 py-2 border-b border-gray-200 mt-4 first:mt-0">
+    <div
+      className="bg-gray-200 px-4 py-2 border-b border-gray-200 mt-4 first:mt-0"
+      data-testid="date-skeleton-label"
+    >
       <div className="h-5 w-32 bg-gray-300 rounded animate-pulse" />
     </div>
   );

--- a/src/components/LoadingSkeleton.tsx
+++ b/src/components/LoadingSkeleton.tsx
@@ -1,0 +1,43 @@
+import { Fragment } from 'react';
+
+interface LoadingSkeletonProps {
+  count?: number;
+}
+
+export function WeatherSkeletonItem() {
+  return (
+    <div className="bg-white border-b border-gray-200 p-4">
+      <div className="h-5 w-40 bg-gray-300 rounded animate-pulse mb-1" />
+
+      <div className="flex items-center justify-start gap-4">
+        <div className="flex flex-col items-center">
+          <div className="h-20 w-20 bg-gray-300 rounded animate-pulse" />
+          <div className="h-4 w-16 bg-gray-300 rounded animate-pulse mt-1" />
+        </div>
+
+        <div className="h-8 w-24 bg-gray-300 rounded animate-pulse" />
+      </div>
+    </div>
+  );
+}
+
+export function DateSkeletonLabel() {
+  return (
+    <div className="bg-gray-200 px-4 py-2 border-b border-gray-200 mt-4 first:mt-0">
+      <div className="h-5 w-32 bg-gray-300 rounded animate-pulse" />
+    </div>
+  );
+}
+
+export function LoadingSkeleton({ count = 5 }: LoadingSkeletonProps) {
+  return (
+    <div role="status" aria-live="polite" aria-label="読み込み中">
+      {Array.from({ length: count }).map((_, index) => (
+        <Fragment key={index}>
+          {(index === 0 || index === 3) && <DateSkeletonLabel />}
+          <WeatherSkeletonItem />
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/WeatherPage.test.tsx
+++ b/src/pages/WeatherPage.test.tsx
@@ -29,9 +29,11 @@ const renderWeatherPage = (cityId: string) => {
 };
 
 describe('WeatherPage', () => {
-  it('ローディング中は「読み込み中...」を表示する', async () => {
+  it('ローディング中はスケルトンを表示する', async () => {
     renderWeatherPage('tokyo');
-    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    expect(
+      screen.getByRole('status', { name: '読み込み中' })
+    ).toBeInTheDocument();
   });
 
   it('データ取得成功時は天気リストを表示する', async () => {
@@ -123,8 +125,10 @@ describe('WeatherPage', () => {
     // リトライボタンをクリック
     await userEvent.click(retryButton);
 
-    // ローディング状態が表示される
-    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    // ローディング状態（スケルトン）が表示される
+    expect(
+      screen.getByRole('status', { name: '読み込み中' })
+    ).toBeInTheDocument();
 
     // 成功時のデータが表示される
     expect(await screen.findByText('2024-01-20 12:00:00')).toBeInTheDocument();

--- a/src/pages/WeatherPage.tsx
+++ b/src/pages/WeatherPage.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom';
 import { useWeather } from '../hooks/useWeather';
 import { WeatherList } from '../components/WeatherList';
 import { ErrorView } from '../components/ErrorView';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { getCityById } from '../constants/cities';
 import { getErrorMessage } from '../lib/errorMessages';
 import type {
@@ -66,7 +67,11 @@ export function WeatherPage() {
   }
 
   if (isFetching) {
-    return <p>読み込み中...</p>;
+    return (
+      <main>
+        <LoadingSkeleton />
+      </main>
+    );
   }
 
   if (isError || !data) {


### PR DESCRIPTION
Fixes #37

## 概要
WeatherListItemと同じ構造を持つアニメーション付きスケルトンUIを実装しました。

## 変更内容
- LoadingSkeletonコンポーネント（WeatherSkeletonItem、DateSkeletonLabel、LoadingSkeleton）を追加
- Tailwind CSSのanimate-pulseを使用したパルスアニメーション
- WAI-ARIA属性でアクセシビリティ対応（role="status"、aria-live="polite"）
- WeatherPageのローディング状態をスケルトン表示に変更
- Storybookストーリー追加（Default、FewItems、ManyItems）
- Testing Libraryのベストプラクティスに従い、getByRoleを使用したテストを実装

## テスト
- ✅ すべてのテストが通過（74テスト）
- ✅ テストカバレッジ: 97.58%
- ✅ LoadingSkeletonコンポーネント: 100%カバレッジ
- ✅ Lint & Format チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 取得中の表示を視覚的なスケルトンに差し替え、読み込み中の体験を改善しました。
  * スケルトンの表示バリエーション（少数／多数／フルスクリーン）をプレビューで確認可能にしました。

* **テスト**
  * スケルトン表示の自動テストを追加しました。
  * 読み込み状態の検証を役割（ARIA）ベースに更新し、アクセシビリティを強化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->